### PR TITLE
🩹 market: mirror fixed repay rounding in position preview

### DIFF
--- a/.changeset/kind-walls-write.md
+++ b/.changeset/kind-walls-write.md
@@ -1,0 +1,5 @@
+---
+"@exactly/lib": patch
+---
+
+🩹 market: mirror fixed repay rounding in position preview

--- a/src/market/fixedRepayPosition.ts
+++ b/src/market/fixedRepayPosition.ts
@@ -39,6 +39,11 @@ export default function fixedRepayPosition(
   const r = mulDiv(netUnassignedEarnings, k, backupSupplied);
   if (r >= WAD) return min(assets + netUnassignedEarnings, totalPosition);
   const x = divWad(assets, WAD - r);
-  if (mulWad(k, x) <= backupSupplied && x <= totalPosition) return x;
+  const scaledPrincipal = mulDiv(x, principal, totalPosition);
+  const gross = mulDiv(unassignedEarnings, min(scaledPrincipal, backupSupplied), backupSupplied);
+  const pos = min(assets + gross - mulWad(gross, backupFeeRate), totalPosition);
+  const earned = mulDiv(unassignedEarnings, min(mulDiv(pos, principal, totalPosition), backupSupplied), backupSupplied);
+  const repay = pos - earned + mulWad(earned, backupFeeRate);
+  if (scaledPrincipal <= backupSupplied && x <= totalPosition) return pos - (repay > assets ? repay - assets : 0n);
   return min(assets + netUnassignedEarnings, totalPosition);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Market UI rounding for fixed-repay calculations now matches the position preview, ensuring consistent and accurate displayed repay amounts.

* **Chores**
  * Bumped library with a patch release and added a release note documenting the rounding alignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exactly/lib/pull/10)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->